### PR TITLE
Use version range for core-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "core-js": "2.4.1"
+    "core-js": "^2.4.1"
   },
   "devDependencies": {
-    "core-js": "2.4.1",
+    "core-js": "^2.4.1",
     "mocha": "~3.0.2"
   }
 }


### PR DESCRIPTION
Will silence some npm unmet peer dependencies warnings with Meteor 1.5 and later as other packages in the dev_bundle relies on later versions of `core-js`.